### PR TITLE
Define field type for "Address" field map field

### DIFF
--- a/inc/SI_GF_Integration_Addon.php
+++ b/inc/SI_GF_Integration_Addon.php
@@ -220,9 +220,10 @@ class SI_GF_Integration_Addon extends GFFeedAddOn {
 								'required' => 1,
 							),
 							array(
-								'name'     => 'address',
-								'label'    => __( 'Address', 'sprout-invoices' ),
-								'required' => 0,
+								'name'       => 'address',
+								'label'      => __( 'Address', 'sprout-invoices' ),
+								'required'   => 0,
+								'field_type' => array( 'address' ),
 							),
 							array(
 								'name'     => 'notes',


### PR DESCRIPTION
When processing the feed, the method is expecting the mapped field to be an address field. This will result in issues when a different field type is mapped.

This PR sets the field type for the Address field in the field map to `address`, only allowing Address fields to be mapped to it.