### PR TITLE
Set the invoice/estimate totals

### DIFF
--- a/inc/SI_GF_Integration_Addon.php
+++ b/inc/SI_GF_Integration_Addon.php
@@ -262,6 +262,8 @@ class SI_GF_Integration_Addon extends GFFeedAddOn {
 
 		$invoice->set_line_items( $submission['line_items'] );
 
+		$invoice->set_calculated_total();
+
 		// notes
 		if ( isset( $submission['notes'] ) ) {
 			$record_id = SI_Internal_Records::new_record( $submission['notes'], SI_Controller::PRIVATE_NOTES_TYPE, $invoice_id, '', 0, false );
@@ -305,6 +307,8 @@ class SI_GF_Integration_Addon extends GFFeedAddOn {
 		$estimate = SI_Estimate::get_instance( $estimate_id );
 
 		$estimate->set_line_items( $submission['line_items'] );
+
+		$estimate->set_calculated_total();
 
 		// notes
 		if ( isset( $submission['notes'] ) ) {


### PR DESCRIPTION
When an invoice or estimate is created and you then visit the Invoices or Estimates list pages the paid (invoice) and total (estimate) columns display a value of 0 for the total.

This PR calls the set_calculated_total method for the invoice and estimate, after the line items are set, so the correct total will now be displayed on those list pages.