### PR TITLE
Fix empty note being added to the new invoice

### DIFF
--- a/inc/SI_GF_Integration_Addon.php
+++ b/inc/SI_GF_Integration_Addon.php
@@ -263,11 +263,11 @@ class SI_GF_Integration_Addon extends GFFeedAddOn {
 		$invoice->set_line_items( $submission['line_items'] );
 
 		// notes
-		if ( isset( $submission['notes'] ) ) {
+		if ( ! empty( $submission['notes'] ) ) {
 			$record_id = SI_Internal_Records::new_record( $submission['notes'], SI_Controller::PRIVATE_NOTES_TYPE, $invoice_id, '', 0, false );
 		}
 
-		if ( isset( $submission['number'] ) ) {
+		if ( ! empty( $submission['number'] ) ) {
 			$invoice->set_invoice_id( $submission['number'] );
 		}
 
@@ -307,11 +307,11 @@ class SI_GF_Integration_Addon extends GFFeedAddOn {
 		$estimate->set_line_items( $submission['line_items'] );
 
 		// notes
-		if ( isset( $submission['notes'] ) ) {
+		if ( ! empty( $submission['notes'] ) ) {
 			$record_id = SI_Internal_Records::new_record( $submission['notes'], SI_Controller::PRIVATE_NOTES_TYPE, $estimate_id, '', 0, false );
 		}
 
-		if ( isset( $submission['number'] ) ) {
+		if ( ! empty( $submission['number'] ) ) {
 			$estimate->set_estimate_id( $submission['number'] );
 		}
 


### PR DESCRIPTION
When the notes setting is not mapped on the feed or it is mapped to a field which is empty on form submission and you later edit the created invoice the history shows an empty private note was added following creation. 

Using `! empty` instead of `isset` ensures the note is only added when a field is mapped and the mapped field contains a value.